### PR TITLE
Allow static build of lib-express to simplify application deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "Simple-Web-Server"]
 	path = Simple-Web-Server
 	url = https://github.com/eidheim/Simple-Web-Server.git
-[submodule "src/Simple-Web-Server"]
-	path = src/Simple-Web-Server
-	url = https://github.com/eidheim/Simple-Web-Server.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,10 @@ before_script:
 script: 
        - mkdir build_gcc
        - cd build_gcc
-       - cmake .. -DBOOST_ROOT=$HOME/cache/boost_1_63_0
+       - cmake .. -DBOOST_ROOT=$HOME/cache/boost_1_63_0 -DUNIT_TESTS=ON
        - make 
        - cd ..
        - mkdir build_gcc_static
        - cd build_gcc_static
-       - cmake .. -DBOOST_ROOT=$HOME/cache/boost_1_63_0 -DBUILD_SHARED_LIBS=OFF 
+       - cmake .. -DBOOST_ROOT=$HOME/cache/boost_1_63_0 -DBUILD_SHARED_LIBS=OFF -DUNIT_TESTS=ON
        - make 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,8 @@ script:
        - cd build_gcc
        - cmake .. -DBOOST_ROOT=$HOME/cache/boost_1_63_0
        - make 
+       - cd ..
+       - mkdir build_gcc_static
+       - cd build_gcc_static
+       - cmake .. -DBOOST_ROOT=$HOME/cache/boost_1_63_0 -DBUILD_SHARED_LIBS=OFF 
+       - make 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.0)
 
 project(express-cpp)
-set(CMAKE_BUILD_TYPE Debug)
 enable_testing()
 
 set (VERSION_MAJOR 0)
@@ -10,9 +9,11 @@ set (VERSION_PATCH 0)
 
 set (VERSION_STRING_INSTALL "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
-add_definitions(--std=c++11)
+if (NOT BUILD_SHARED_LIBRARIES) 
+  SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+endif() 
 
-find_package(Boost 1.59 REQUIRED COMPONENTS filesystem regex system thread filesystem date_time)
+find_package(Boost 1.59 REQUIRED COMPONENTS regex coroutine context thread filesystem system date_time)
 find_package(Threads REQUIRED)
 
 set(EXPRESS_HDR ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -23,7 +24,7 @@ include_directories(${SIMPLE_WEB_SERVER_HDR})
 
 
 file(GLOB_RECURSE EXPRESS_SRC "src/*.cpp")
-add_library(express-cpp SHARED ${EXPRESS_SRC})
+add_library(express-cpp ${EXPRESS_SRC})
 set_target_properties(express-cpp PROPERTIES VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 target_link_libraries(express-cpp ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 add_executable(express-test test/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.0)
 
 project(express-cpp)
-enable_testing()
+
+option (UNIT_TESTS "Enable Unit Tests" OFF)
 
 set (VERSION_MAJOR 0)
 set (VERSION_MINOR 1)
@@ -27,10 +28,13 @@ file(GLOB_RECURSE EXPRESS_SRC "src/*.cpp")
 add_library(express-cpp ${EXPRESS_SRC})
 set_target_properties(express-cpp PROPERTIES VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 target_link_libraries(express-cpp ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-add_executable(express-test test/main.cpp)
-target_link_libraries(express-test express-cpp)
 
-add_test(initial-test express-test)
+if (UNIT_TESTS)
+  enable_testing()
+  add_executable(express-test test/main.cpp)
+  target_link_libraries(express-test express-cpp)
+  add_test(initial-test express-test)
+endif()
 
 #installing headers, libs and binaries
 install(TARGETS express-cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,26 @@
 cmake_minimum_required(VERSION 2.8.0)
-
 project(express-cpp)
 
+set (CMAKE_CXX_STANDARD 11)
+
 option (UNIT_TESTS "Enable Unit Tests" OFF)
+option (BUILD_SHARED_LIBS "Building shared libraries" ON)
 
 set (VERSION_MAJOR 0)
 set (VERSION_MINOR 1)
 set (VERSION_PATCH 0)
 
-set (VERSION_STRING_INSTALL "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
-
-if (NOT BUILD_SHARED_LIBRARIES) 
-  SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+if (NOT BUILD_SHARED_LIBS) 
+  if (UNIX OR APPLE)
+    SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  elseif(WIN32)
+    SET(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+  endif()
 endif() 
 
-find_package(Boost 1.59 REQUIRED COMPONENTS regex coroutine context thread filesystem system date_time)
+set (VERSION_STRING_INSTALL "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+
+find_package(Boost 1.59 REQUIRED COMPONENTS regex thread filesystem system date_time)
 find_package(Threads REQUIRED)
 
 set(EXPRESS_HDR ${CMAKE_CURRENT_SOURCE_DIR}/src)


### PR DESCRIPTION
Hey @linkineo and how is the weekend ? :smile:

I just made some change to the build files for the purpose of deploying more easily application built on top of express : 
  - allow static build.
  - avoid compilation of unit test.

See you soon